### PR TITLE
Refactor: 영화 배치 API에서 발생하는 문제 수정

### DIFF
--- a/src/main/java/com/catcher/batch/core/dto/MovieApiResponse.java
+++ b/src/main/java/com/catcher/batch/core/dto/MovieApiResponse.java
@@ -65,6 +65,12 @@ public class MovieApiResponse {
             this.posterPath = "https://image.tmdb.org/t/p/w300" + posterPath;
         }
 
+        @JsonProperty("title")
+        public void setTitle(String title){
+            String removeEmojiRegex = "[\\x{1F600}-\\x{1F64F}\\x{1F300}-\\x{1F5FF}\\x{1F680}-\\x{1F6FF}\\x{1F700}-\\x{1F77F}\\x{1F780}-\\x{1F7FF}\\x{1F800}-\\x{1F8FF}\\x{1F900}-\\x{1F9FF}\\x{1FA00}-\\x{1FA6F}\\x{1FA70}-\\x{1FAFF}]";
+            this.title = title.replaceAll(removeEmojiRegex,"");
+        }
+
         @Override
         public ZonedDateTime getEndAt() {
             return null;

--- a/src/main/java/com/catcher/batch/core/service/MovieService.java
+++ b/src/main/java/com/catcher/batch/core/service/MovieService.java
@@ -14,9 +14,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -48,8 +46,10 @@ public class MovieService {
         List<CatcherItem> newItemList = new ArrayList<>();
         List<String> itemHashValueList = new ArrayList<>();
 
+        Set<String> singleMovieItemFromApi = new HashSet<>();
+
         for(MovieApiResponse.MovieItem response : (List<MovieApiResponse.MovieItem>)responses){
-            if(response.getReleaseDate().isBlank() || response.getReleaseDate().isEmpty()) continue;
+            if(response.getReleaseDate() == null || response.getReleaseDate().isEmpty()) continue;
 
             String apiHashKey = response.getHashString();
             CatcherItem item = response.toEntity(null, category);
@@ -58,7 +58,10 @@ public class MovieService {
                 itemHashValueList.add(item.getItemHashValue());
             }
             else{
-                newItemList.add(item);
+                if(!singleMovieItemFromApi.contains(item.getItemHashValue())){
+                    newItemList.add(item);
+                    singleMovieItemFromApi.add(item.getItemHashValue());
+                }
             }
         }
 


### PR DESCRIPTION
### 변경 사항
1. Title에 이모지가 있는 경우가 존재함에 따라 DB에 넣을때 에러 발생 -> API 데이터를 MovieItem으로 변환할 때 이모지 제거
2. API 데이터에서 중복된 영화 아이템이 오는 경우가 존재 -> Set을 통해 이미 받은 데이터면 처리하지 않음